### PR TITLE
chore: Update composer.json to use "Razor\\Paystack\\Providers\\PaystackServiceProvider"

### DIFF
--- a/packages/Razor/Paystack/composer.json
+++ b/packages/Razor/Paystack/composer.json
@@ -6,7 +6,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Razor\\Paystack\\": "packages/"
+            "Razor\\Paystack\\": "src/"
         }
     }
 }


### PR DESCRIPTION
The `composer.json` file is modified to update the autoload configuration, changing the namespace for the `Razor\\Paystack\\` class to point to the `src/` directory instead of the `packages/` directory. This ensures that the correct file path is used for autoloading the class.